### PR TITLE
Fix out-of-bounds read in eval_rpn

### DIFF
--- a/rpneval.c
+++ b/rpneval.c
@@ -22,7 +22,7 @@ char *pc;
 pc = expr;
 	while(*pc != '\0')
 	{
-		if(*(pc -1) == ' ' || *(pc -1) == '\t' || firstletter)
+		if(firstletter || *(pc -1) == ' ' || *(pc -1) == '\t')
 		{
 			firstletter = 0;
 			if(*pc >= '0' && *pc <= '9') //it's a number... push it on the stack


### PR DESCRIPTION
This bug was automatically found by executing the program with [Safe Sulong](https://github.com/graalvm/sulong/blob/master/docs/SAFE-SULONG.md).